### PR TITLE
Fixed out of memory issue on class definition listing

### DIFF
--- a/Utils/OptionsProvider.php
+++ b/Utils/OptionsProvider.php
@@ -19,6 +19,7 @@ class OptionsProvider implements MultiSelectOptionsProviderInterface
         $classesList = new ClassDefinition\Listing();
         $classesList->setOrderKey('name');
         $classesList->setOrder('asc');
+        $classesList->setCondition('name NOT LIKE ?', $context['class']->getName() . '%');
         
         $classes = $classesList->load();
         $result = array();


### PR DESCRIPTION
I added this condition on the classes listing to prevent out of memory issues that is causing by listing it's own class.